### PR TITLE
bug-erro-menu-modulos - ajuste para não ficar null - 13/12/2023

### DIFF
--- a/src/layouts/dashboard/config-navigation.js
+++ b/src/layouts/dashboard/config-navigation.js
@@ -162,11 +162,14 @@ export function useNavData() {
     ]
   } else {
     try {
-      const modulosPermitidos = user?.permissao_usuario[0]?.permissao_modulo.map(permissaoModulo => {
+      let modulosPermitidos = user?.permissao_usuario[0]?.permissao_modulo.map(permissaoModulo => {
         if (permissaoModulo.cadastrar || permissaoModulo.editar || permissaoModulo.deletar) {
           return permissaoModulo.modulo?.namespace;
         }
       });
+
+      modulosPermitidos ??= [];
+
       items.push({
         title: t('home (dashboard)'),
         path: paths.dashboard.root,


### PR DESCRIPTION
![Captura de tela 2023-12-13 092255](https://github.com/QuantumTechBr/AlfaFront/assets/38680809/ac07b07f-dfbc-433e-a6f2-2645acf8c34e)
O erro aconteceu apenas 1 vez ao fazer logout de uma conta de professor.
Acontece de forma aleatória.
Esse PR visa evitar que aconteça novamente.